### PR TITLE
[EE-946] Use our 502 resilient pip

### DIFF
--- a/python/pip_install/repositories.bzl
+++ b/python/pip_install/repositories.bzl
@@ -52,8 +52,9 @@ _RULE_DEPS = [
     ),
     (
         "pypi__pip",
-        "https://files.pythonhosted.org/packages/09/bd/2410905c76ee14c62baf69e3f4aa780226c1bbfc9485731ad018e35b0cb5/pip-22.3.1-py3-none-any.whl",
-        "908c78e6bc29b676ede1c4d57981d490cb892eb45cd8c214ab6298125119e077",
+        # Use a vendored pip which will retry HTTP 502s
+        "https://codeartifact-proxy.abnormal.dev/pip/22.1.2.post1+abnormal.03d64aee90f/pip-22.1.2.post1+abnormal.03d64aee90f-py3-none-any.whl",
+        "59791080b47583f47fc224132a28bc79f4b99e44b69993f0f298f2c816415b58",
     ),
     (
         "pypi__pip_tools",


### PR DESCRIPTION
Use our patched pip which will retry HTTP 502s

## Testing
Using patch
```diff
diff --git a/WORKSPACE b/WORKSPACE
index 921b9df883c..860e827e02c 100644
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,7 +44,7 @@ bazel_skylib_workspace()

 git_repository(
     name = "rules_python",
-    commit = "addc0798da1218e99d0502e8b76118b54eaf8ef3",  # 0.21.0 + #1166
+    commit = "61f29f547c1dee4eb926b6e64162af4e866b8987",
     remote = "https://git-proxy.usea1.e.abnml.io/abnormal-security/rules_python.git",
 )

@@ -347,7 +347,7 @@ pip_parse(
     environment = environment,
     extra_pip_args = extra_pip_args,
     python_interpreter_target = "@local_py//:python3",
-    requirement_clusters = requirement_clusters,
+    # requirement_clusters = requirement_clusters,
     requirements_lock = requirements_lock,
 )
 ```
 
 Run tests (failures are expected, as the referenced commit does not contain the #3 patch)
 
 ```shell-session
 $ bazel test //projects/...
Starting local Bazel server and connecting to it...
INFO: Invocation ID: da94d8f7-119d-4c67-a0b6-b68ce2eff11c
ERROR: /private/var/tmp/_bazel_arrdem/64fd9f51655edad1a031ed416b537465/external/pypi_oletools/BUILD.bazel:22:11: in py_library rule @pypi_oletools//:pkg: cycle in dependency graph:
    //projects/ee/py-binary-example:py-binary-example (0f263cf8442d906dbfa3f165f578f369610c5270cb5d648a87f30f540a9bbb14)
.-> @pypi_oletools//:pkg (0f263cf8442d906dbfa3f165f578f369610c5270cb5d648a87f30f540a9bbb14)
|   @pypi_pcodedmp//:pkg (0f263cf8442d906dbfa3f165f578f369610c5270cb5d648a87f30f540a9bbb14)
`-- @pypi_oletools//:pkg (0f263cf8442d906dbfa3f165f578f369610c5270cb5d648a87f30f540a9bbb14)
WARNING: errors encountered while analyzing target '//projects/ee/py-binary-example:py-binary-example': it will not be built
INFO: Analysis succeeded for only 44 of 45 top-level targets
INFO: Analyzed 45 targets (605 packages loaded, 32690 targets configured).
INFO: Found 35 targets and 9 test targets...
INFO: From Executing genrule //projects/cloud/pacman:compile_serdes:
[INFO    ] Compiling string...
[INFO    ] Compiling string...
[INFO    ] Compiling MetaConfig...
[INFO    ] Compiling TeamManifest...
[INFO    ] Compiling ComponentManifest...
[INFO    ] Compiling VersionDefinition...
[INFO    ] Compiling ScaleDefinition...
[INFO    ] Compiling SettingDefinition...
[INFO    ] Compiling ProfileDefinitions...
[INFO    ] Compiling ProfileDefinition...
[INFO    ] Compiling PermissionDefinition...
[INFO    ] Compiling ProductManifest...
[INFO    ] Compiling AppManifest...
[INFO    ] Compiling SettingValueBasicListDefinition...
[INFO    ] Compiling SettingValueBasicMapDefinition...
[INFO    ] Compiling RealmConfig...
[INFO    ] Compiling PartitionId...
[INFO    ] Compiling RegionId...
[INFO    ] Compiling ComponentConfig...
[INFO    ] Compiling DependencyConfig...
[INFO    ] Compiling EndpointConfig...
[INFO    ] Compiling DependentConfig...
[INFO    ] Compiling ServiceConfig...
[INFO    ] Compiling ComponentId...
[INFO    ] Compiling ComponentId...
[INFO    ] Compiling Version...
[INFO    ] Compiling Input...
[INFO    ] Compiling Any...
[INFO    ] Compiling Any...
INFO: From Executing genrule //projects/ee/square:compile_serdes:
[INFO    ] Compiling Version...
[INFO    ] Compiling Artifact...
ERROR: command succeeded, but not all targets were analyzed
INFO: Elapsed time: 64.270s, Critical Path: 9.01s
INFO: 101 processes: 14 disk cache hit, 73 internal, 14 darwin-sandbox.
FAILED: Build did NOT complete successfully
//projects/ee/pip-merge:test_evaluator.py                       (cached) PASSED in 4.4s
//projects/ee/py-pytest-example:test_lib.py                     (cached) PASSED in 1.8s
//projects/cloud/pacman:test_helm.py                                     PASSED in 2.5s
//projects/cloud/pacman:test_input_macros.py                             PASSED in 1.9s
//projects/cloud/pacman:test_input_resolver.py                           PASSED in 2.0s
//projects/cloud/pacman:test_realm_parsing.py                            PASSED in 2.3s
//projects/cloud/pacman:test_util.py                                     PASSED in 2.1s
//projects/ee/pronghorn:test_import_parser.py                            PASSED in 2.2s
//projects/ee/pronghorn:test_starlark.py                                 PASSED in 1.5s

Executed 7 out of 9 tests: 9 tests pass.
All tests passed but there were other errors during the build.
 ```