### PR TITLE
fix(whl_library): `:data` needs to be data for the library

### DIFF
--- a/python/pip_install/private/generate_whl_library_build_bazel.bzl
+++ b/python/pip_install/private/generate_whl_library_build_bazel.bzl
@@ -258,7 +258,7 @@ def generate_whl_library_build_bazel(
     """
 
     additional_content = []
-    data = []
+    data = [":data"]
     srcs_exclude = []
     data_exclude = [] + data_exclude
     dependencies = sorted([normalize_name(d) for d in dependencies])

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -609,7 +609,7 @@ class Wheel:
         destination = installer.destinations.SchemeDictionaryDestination(
             installation_schemes,
             # TODO Should entry_point scripts also be handled by installer rather than custom code?
-            interpreter="/usr/bin/env python3",
+            interpreter="python3",
             script_kind="posix",
             destdir=directory,
             bytecode_optimization_levels=[],

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -15,7 +15,6 @@
 """Utility class to inspect an extracted wheel directory"""
 
 import email
-import pathlib
 import platform
 import re
 import sys

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -15,6 +15,7 @@
 """Utility class to inspect an extracted wheel directory"""
 
 import email
+import pathlib
 import platform
 import re
 import sys
@@ -609,7 +610,7 @@ class Wheel:
         destination = installer.destinations.SchemeDictionaryDestination(
             installation_schemes,
             # TODO Should entry_point scripts also be handled by installer rather than custom code?
-            interpreter="python3",
+            interpreter="/dev/null",
             script_kind="posix",
             destdir=directory,
             bytecode_optimization_levels=[],

--- a/python/pip_install/tools/wheel_installer/wheel.py
+++ b/python/pip_install/tools/wheel_installer/wheel.py
@@ -609,7 +609,7 @@ class Wheel:
         destination = installer.destinations.SchemeDictionaryDestination(
             installation_schemes,
             # TODO Should entry_point scripts also be handled by installer rather than custom code?
-            interpreter="/dev/null",
+            interpreter="/usr/bin/env python3",
             script_kind="posix",
             destdir=directory,
             bytecode_optimization_levels=[],


### PR DESCRIPTION
This patch fixes an oversight in the expansion of the `BUILD.bazel` file template to make the `:data` target which includes wheel installation content such as `/bin` entrypoints in the case of `ruff` as part of the library target pointed to by `py_requirement`.

This allows for py_library/py_binary/... consumers to take dependencies both on data files and on potential binary artifacts packaged as part of a PyPi "library" transparently via `py_requirement` and associated machinery.