### PR TITLE
[DEVI-254] Pin external actions libs into correct shas

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       # Checkout the code
-      - uses: actions/checkout@v2
-      - uses: jpetrucciani/mypy-check@master
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: jpetrucciani/mypy-check@f5346c698c77f7365182de7e20ea71f85b1fe8cf # v1.15.0
         with:
           requirements: 1.6.0
           python_version: 3.8
           path: 'python/runfiles'
-      - uses: jpetrucciani/mypy-check@master
+      - uses: jpetrucciani/mypy-check@f5346c698c77f7365182de7e20ea71f85b1fe8cf # v1.15.0
         with:
           requirements: 1.6.0
           python_version: 3.8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Create release archive and notes
         run: .github/workflows/create_archive_and_notes.sh
       - name: Publish wheel dist
@@ -37,7 +37,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: bazel run --stamp --embed_label=${{ github.ref_name }} //python/runfiles:wheel.publish
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 # v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Due to recent security exposure issues from 3rd party lib actions. We realize it's not quite safe to use with version but should've managed it with exact safe sha along with allow lists.
https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/

Replacement is based on.
https://docs.google.com/spreadsheets/d/1n6dk6bVW7kWBratbpC9YMpGAgx0W56DbquSYy5Eo_5A/edit?gid=0#gid=0

