### PR TITLE
fix: allow spaces in whl_librarys (#2334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,32 +17,604 @@ A brief description of the categories of changes:
 * Particular sub-systems are identified using parentheses, e.g. `(bzlmod)` or
   `(docs)`.
 
+{#v0-0-0}
 ## Unreleased
 
+[0.0.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.0.0
+
+{#v0-0-0-changed}
 ### Changed
+* (deps) (WORKSPACE only) rules_cc 0.0.13 and protobuf 27.0 is now the default
+  version used; this for Bazel 8+ support (previously version was rules_cc 0.0.9
+  and no protobuf version specified)
+  ([2310](https://github.com/bazelbuild/rules_python/issues/2310)).
+* (publish) The dependencies have been updated to the latest available versions
+  for the `twine` publishing rule.
+
+{#v0-0-0-fixed}
+### Fixed
+* (bzlmod) Generate `config_setting` values for all available toolchains instead
+  of only the registered toolchains, which restores the previous behaviour that
+  `bzlmod` users would have observed.
+* (pypi) (Bazel 7.4+) Allow spaces in filenames included in `whl_library`s
+  ([617](https://github.com/bazelbuild/rules_python/issues/617)).
+
+{#v0-0-0-added}
+### Added
+* (publish) The requirements file for the `twine` publishing rules have been
+  updated to have a new convention: `requirements_darwin.txt`,
+  `requirements_linux.txt`, `requirements_windows.txt` for each respective OS
+  and one extra file `requirements_universal.txt` if you prefer a single file.
+  The `requirements.txt` file may be removed in the future.
+
+{#v0-0-0-removed}
+### Removed
+* Nothing yet
+
+{#v0-37-1}
+## [0.37.1] - 2024-10-22
+
+[0.37.1]: https://github.com/bazelbuild/rules_python/releases/tag/0.37.1
+
+{#v0-37-1-fixed}
+### Fixed
+* (rules) Setting `--incompatible_python_disallow_native_rules` no longer
+  causes rules_python rules to fail
+  ([#2326](https://github.com/bazelbuild/rules_python/issues/2326)).
+
+{#v0-37-0}
+## [0.37.0] - 2024-10-18
+
+[0.37.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.37.0
+
+{#v0-37-0-changed}
+### Changed
+* **BREAKING** `py_library` no longer puts its source files or generated pyc
+  files in runfiles; it's the responsibility of consumers (e.g. binaries) to
+  populate runfiles with the necessary files. Adding source files to runfiles
+  can be temporarily restored by setting {obj}`--add_srcs_to_runfiles=enabled`,
+  but this flag will be removed in a subsequent releases.
+* {obj}`PyInfo.transitive_sources` is now added to runfiles. These files are
+  `.py` files that are required to be added to runfiles by downstream binaries
+  (or equivalent).
+* (toolchains) `py_runtime.implementation_name` now defaults to `cpython`
+  (previously it defaulted to None).
+* (toolchains) The exec tools toolchain is enabled by default. It can be
+  disabled by setting
+  {obj}`--@rules_python//python/config_settings:exec_tools_toolchain=disabled`.
+* (deps) stardoc 0.6.2 added as dependency.
+
+{#v0-37-0-fixed}
+### Fixed
+* (bzlmod) The `python.override(minor_mapping)` now merges the default and the
+  overridden versions ensuring that the resultant `minor_mapping` will always
+  have all of the python versions.
+* (bzlmod) The default value for the {obj}`--python_version` flag will now be
+  always set to the default python toolchain version value.
+* (bzlmod) correctly wire the {attr}`pip.parse.extra_pip_args` all the
+  way to {obj}`whl_library`. What is more we will pass the `extra_pip_args` to
+  {obj}`whl_library` for `sdist` distributions when using
+  {attr}`pip.parse.experimental_index_url`. See
+  [#2239](https://github.com/bazelbuild/rules_python/issues/2239).
+* (whl_filegroup): Provide per default also the `RECORD` file
+* (py_wheel): `RECORD` file entry elements are now quoted if necessary when a
+  wheel is created
+* (whl_library) truncate progress messages from the repo rule to better handle
+  case where a requirement has many `--hash=sha256:...` flags
+* (rules) `compile_pip_requirements` passes `env` to the `X.update` target (and
+  not only to the `X_test` target, a bug introduced in
+  [#1067](https://github.com/bazelbuild/rules_python/pull/1067)).
+* (bzlmod) In hybrid bzlmod with WORKSPACE builds,
+  `python_register_toolchains(register_toolchains=True)` is respected
+  ([#1675](https://github.com/bazelbuild/rules_python/issues/1675)).
+* (precompiling) The {obj}`pyc_collection` attribute now correctly
+  enables (or disables) using pyc files from targets transitively
+* (pip) Skip patching wheels not matching `pip.override`'s `file`
+  ([#2294](https://github.com/bazelbuild/rules_python/pull/2294)).
+* (chore): Add a `rules_shell` dev dependency and moved a `sh_test` target
+  outside of the `//:BUILD.bazel` file.
+  Fixes [#2299](https://github.com/bazelbuild/rules_python/issues/2299).
+
+{#v0-37-0-added}
+### Added
+* (py_wheel) Now supports `compress = (True|False)` to allow disabling
+  compression to speed up development.
+* (toolchains): A public `//python/config_settings:python_version_major_minor` has
+  been exposed for users to be able to match on the `X.Y` version of a Python
+  interpreter.
+* (api) Added {obj}`merge_py_infos()` so user rules can merge and propagate
+  `PyInfo` without losing information.
+* (toolchains) New Python versions available: 3.13.0 using the [20241008] release.
+* (toolchains): Bump default toolchain versions to:
+    * `3.8 -> 3.8.20`
+    * `3.9 -> 3.9.20`
+    * `3.10 -> 3.10.15`
+    * `3.11 -> 3.11.10`
+    * `3.12 -> 3.12.7`
+* (coverage) Add support for python 3.13 and bump `coverage.py` to 7.6.1.
+* (bzlmod) Add support for `download_only` flag to disable usage of `sdists`
+  when {bzl:attr}`pip.parse.experimental_index_url` is set.
+* (api) PyInfo fields: {obj}`PyInfo.transitive_implicit_pyc_files`,
+  {obj}`PyInfo.transitive_implicit_pyc_source_files`.
+
+[20241008]: https://github.com/indygreg/python-build-standalone/releases/tag/20241008
+
+{#v0-37-0-removed}
+### Removed
+* (precompiling) {obj}`--precompile_add_to_runfiles` has been removed.
+* (precompiling) {obj}`--pyc_collection` has been removed. The `pyc_collection`
+  attribute now bases its default on {obj}`--precompile`.
+* (precompiling) The {obj}`precompile=if_generated_source` value has been removed.
+* (precompiling) The {obj}`precompile_source_retention=omit_if_generated_source` value has been removed.
+
+{#v0-36-0}
+## [0.36.0] - 2024-09-24
+
+[0.36.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.36.0
+
+{#v0-36-0-changed}
+### Changed
+* (gazelle): Update error messages when unable to resolve a dependency to be more human-friendly.
+* (flags) The {obj}`--python_version` flag now also returns
+  {obj}`config_common.FeatureFlagInfo`.
+* (toolchain): The toolchain patches now expose the `patch_strip` attribute
+  that one should use when patching toolchains. Please set it if you are
+  patching python interpreter. In the next release the default will be set to
+  `0` which better reflects the defaults used in public `bazel` APIs.
+* (toolchains) When {obj}`py_runtime.interpreter_version_info` isn't specified,
+  the {obj}`--python_version` flag will determine the value. This allows
+  specifying the build-time Python version for the
+  {obj}`runtime_env_toolchains`.
+* (toolchains) {obj}`py_cc_toolchain.libs` and {obj}`PyCcToolchainInfo.libs` is
+  optional. This is to support situations where only the Python headers are
+  available.
+* (bazel) Minimum bazel 7 version that we test against has been bumped to `7.1`.
+
+{#v0-36-0-fixed}
+### Fixed
+* (whl_library): Remove `--no-index` and add `--no-build-isolation` to the
+  `pip install` command when installing a wheel from a local file, which happens
+  when `experimental_index_url` flag is used.
+* (bzlmod) get the path to the host python interpreter in a way that results in
+  platform non-dependent hashes in the lock file when the requirement markers need
+  to be evaluated.
+* (bzlmod) correctly watch sources used for evaluating requirement markers for
+  any changes so that the repository rule or module extensions can be
+  re-evaluated when the said files change.
+* (gazelle): Fix incorrect use of `t.Fatal`/`t.Fatalf` in tests.
+* (toolchain) Omit third-party python packages from coverage reports from
+  stage2 bootstrap template.
+* (bzlmod) Properly handle relative path URLs in parse_simpleapi_html.bzl
+* (gazelle) Correctly resolve deps that have top-level module overlap with a gazelle_python.yaml dep module
+* (rules) Make `RUNFILES_MANIFEST_FILE`-based invocations work when used with
+  {obj}`--bootstrap_impl=script`. This fixes invocations using non-sandboxed
+  test execution with `--enable_runfiles=false --build_runfile_manifests=true`.
+  ([#2186](https://github.com/bazelbuild/rules_python/issues/2186)).
+* (py_wheel) Fix incorrectly generated `Required-Dist` when specifying requirements with markers
+  in extra_requires in py_wheel rule.
+* (rules) Prevent pytest from trying run the generated stage2
+  bootstrap .py file when using {obj}`--bootstrap_impl=script`
+* (toolchain) The {bzl:obj}`gen_python_config_settings` has been fixed to include
+  the flag_values from the platform definitions.
+
+{#v0-36-0-added}
+### Added
+* (bzlmod): Toolchain overrides can now be done using the new
+  {bzl:obj}`python.override`, {bzl:obj}`python.single_version_override` and
+  {bzl:obj}`python.single_version_platform_override` tag classes.
+  See [#2081](https://github.com/bazelbuild/rules_python/issues/2081).
+* (rules) Executables provide {obj}`PyExecutableInfo`, which contains
+  executable-specific information useful for packaging an executable or
+  or deriving a new one from the original.
+* (py_wheel) Removed use of bash to avoid failures on Windows machines which do not
+  have it installed.
+* (docs) Automatically generated documentation for {bzl:obj}`python_register_toolchains`
+  and related symbols.
+* (toolchains) Added {attr}`python_repository.patch_strip` attribute for
+  allowing values that are other than `1`, which has been hard-coded up until
+  now. If you are relying on the undocumented `patches` support in
+  `TOOL_VERSIONS` for registering patched toolchains please consider setting
+  the `patch_strip` explicitly to `1` if you depend on this value - in the
+  future the value may change to default to `0`.
+* (toolchains) Added `//python:none`, a special target for use with
+  {obj}`py_exec_tools_toolchain.exec_interpreter` to treat the value as `None`.
+
+{#v0-36-0-removed}
+### Removed
+* (toolchains): Removed accidentally exposed `http_archive` symbol from
+  `python/repositories.bzl`.
+* (toolchains): An internal _is_python_config_setting_ macro has been removed.
+
+{#v0-35-0}
+## [0.35.0] - 2024-08-15
+
+[0.35.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.35.0
+
+{#v0-35-0-changed}
+### Changed
+* (whl_library) A better log message when the wheel is built from an sdist or
+  when the wheel is downloaded using `download_only` feature to aid debugging.
+* (gazelle): Simplify and make gazelle_python.yaml have only top level package name.
+  It would work well in cases to reduce merge conflicts.
+* (toolchains): Change some old toochain versions to use [20240726] release to
+  include dependency updates `3.8.19`, `3.9.19`, `3.10.14`, `3.11.9`
+* (toolchains): Bump default toolchain versions to:
+    * `3.12 -> 3.12.4`
+* (rules) `PYTHONSAFEPATH` is inherited from the calling environment to allow
+  disabling it (Requires {obj}`--bootstrap_impl=script`)
+  ([#2060](https://github.com/bazelbuild/rules_python/issues/2060)).
+
+{#v0-35-0-fixed}
+### Fixed
+* (rules) `compile_pip_requirements` now sets the `USERPROFILE` env variable on
+  Windows to work around an issue where `setuptools` fails to locate the user's
+  home directory.
+* (rules) correctly handle absolute URLs in parse_simpleapi_html.bzl.
+* (rules) Fixes build targets linking against `@rules_python//python/cc:current_py_cc_libs`
+  in host platform builds on macOS, by editing the `LC_ID_DYLIB` field of the hermetic interpreter's
+  `libpython3.x.dylib` using `install_name_tool`, setting it to its absolute path under Bazel's
+  execroot.
+* (rules) Signals are properly received when using {obj}`--bootstrap_impl=script`
+  (for non-zip builds).
+  ([#2043](https://github.com/bazelbuild/rules_python/issues/2043))
+* (rules) Fixes Python builds when the `--build_python_zip` is set to `false` on
+  Windows. See [#1840](https://github.com/bazelbuild/rules_python/issues/1840).
+* (rules) Fixes Mac + `--build_python_zip` + {obj}`--bootstrap_impl=script`
+  ([#2030](https://github.com/bazelbuild/rules_python/issues/2030)).
+* (rules) User dependencies come before runtime site-packages when using
+  {obj}`--bootstrap_impl=script`.
+  ([#2064](https://github.com/bazelbuild/rules_python/issues/2064)).
+* (rules) Version-aware rules now return both `@_builtins` and `@rules_python`
+  providers instead of only one.
+  ([#2114](https://github.com/bazelbuild/rules_python/issues/2114)).
+* (pip) Fixed pypi parse_simpleapi_html function for feeds with package metadata
+  containing ">" sign
+* (toolchains) Added missing executable permission to
+  `//python/runtime_env_toolchains` interpreter script so that it is runnable.
+  ([#2085](https://github.com/bazelbuild/rules_python/issues/2085)).
+* (pip) Correctly use the `sdist` downloaded by the bazel downloader when using
+  `experimental_index_url` feature. Fixes
+  [#2091](https://github.com/bazelbuild/rules_python/issues/2090).
+* (gazelle) Make `gazelle_python_manifest.update` manual to avoid unnecessary
+  network behavior.
+* (bzlmod): The conflicting toolchains during `python` extension will no longer
+  cause warnings by default. In order to see the warnings for diagnostic purposes
+  set the env var `RULES_PYTHON_REPO_DEBUG_VERBOSITY` to one of `INFO`, `DEBUG` or `TRACE`.
+  Fixes [#1818](https://github.com/bazelbuild/rules_python/issues/1818).
+* (runfiles) Make runfiles lookups work for the situation of Bazel 7,
+  Python 3.9 (or earlier, where safepath isn't present), and the Rlocation call
+  in the same directory as the main file.
+  Fixes [#1631](https://github.com/bazelbuild/rules_python/issues/1631).
+
+{#v0-35-0-added}
+### Added
+* (rules) `compile_pip_requirements` supports multiple requirements input files as `srcs`.
+* (rules) `PYTHONSAFEPATH` is inherited from the calling environment to allow
+  disabling it (Requires {obj}`--bootstrap_impl=script`)
+  ([#2060](https://github.com/bazelbuild/rules_python/issues/2060)).
+* (gazelle) Added `python_generation_mode_per_package_require_test_entry_point`
+  in order to better accommodate users who use a custom macro,
+  [`pytest-bazel`][pytest_bazel], [rules_python_pytest] or `rules_py`
+  [py_test_main] in order to integrate with `pytest`. Currently the default
+  flag value is set to `true` for backwards compatible behaviour, but in the
+  future the flag will be flipped be `false` by default.
+* (toolchains) New Python versions available: `3.12.4` using the [20240726] release.
+* (pypi) Support env markers in requirements files. Note, that this means that
+  if your requirements files contain env markers, the Python interpreter will
+  need to be run during bzlmod phase to evaluate them. This may incur
+  downloading an interpreter (for hermetic-based builds) or cause non-hermetic
+  behavior (if using a system Python).
+
+[rules_python_pytest]: https://github.com/caseyduquettesc/rules_python_pytest
+[py_test_main]: https://docs.aspect.build/rulesets/aspect_rules_py/docs/rules/#py_pytest_main
+[pytest_bazel]: https://pypi.org/project/pytest-bazel
+[20240726]: https://github.com/indygreg/python-build-standalone/releases/tag/20240726
+
+{#v0-34-0}
+## [0.34.0] - 2024-07-04
+
+[0.34.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.34.0
+
+{#v0-34-0-changed}
+### Changed
+* `protobuf`/`com_google_protobuf` dependency bumped to `v24.4`
+* (bzlmod): optimize the creation of config settings used in pip to
+  reduce the total number of targets in the hub repo.
+* (toolchains) The exec tools toolchain now finds its interpreter by reusing
+  the regular interpreter toolchain. This avoids having to duplicate specifying
+  where the runtime for the exec tools toolchain is.
+* (toolchains) ({obj}`//python:autodetecting_toolchain`) is deprecated. It is
+  replaced by {obj}`//python/runtime_env_toolchains:all`. The old target will be
+  removed in a future release.
+
+{#v0-34-0-fixed}
+### Fixed
+* (bzlmod): When using `experimental_index_url` the `all_requirements`,
+  `all_whl_requirements` and `all_data_requirements` will now only include
+  common packages that are available on all target platforms. This is to ensure
+  that packages that are only present for some platforms are pulled only via
+  the `deps` of the materialized `py_library`. If you would like to include
+  platform specific packages, using a `select` statement with references to the
+  specific package will still work (e.g.
+  ```
+  my_attr = all_requirements + select(
+      {
+          "@platforms//os:linux": ["@pypi//foo_available_only_on_linux"],
+          "//conditions:default": [],
+      }
+  )
+  ```
+* (bzlmod): Targets in `all_requirements` now use the same form as targets returned by the `requirement` macro.
+* (rules) Auto exec groups are enabled. This allows actions run by the rules,
+  such as precompiling, to pick an execution platform separately from what
+  other toolchains support.
+* (providers) {obj}`PyRuntimeInfo` doesn't require passing the
+  `interpreter_version_info` arg.
+* (bzlmod) Correctly pass `isolated`, `quiet` and `timeout` values to `whl_library`
+  and drop the defaults from the lock file.
+* (whl_library) Correctly handle arch-specific dependencies when we encounter a
+  platform specific wheel and use `experimental_target_platforms`.
+  Fixes [#1996](https://github.com/bazelbuild/rules_python/issues/1996).
+* (rules) The first element of the default outputs is now the executable again.
+* (pip) Fixed crash when pypi packages lacked a sha (e.g. yanked packages)
+
+{#v0-34-0-added}
+### Added
+* (toolchains) {obj}`//python/runtime_env_toolchains:all`, which is a drop-in
+  replacement for the "autodetecting" toolchain.
+* (gazelle) Added new `python_label_convention` and `python_label_normalization` directives. These directive
+  allows altering default Gazelle label format to third-party dependencies useful for re-using Gazelle plugin
+  with other rules, including `rules_pycross`. See [#1939](https://github.com/bazelbuild/rules_python/issues/1939).
+
+{#v0-34-0-removed}
+### Removed
+* (pip): Removes the `entrypoint` macro that was replaced by `py_console_script_binary` in 0.26.0.
+
+{#v0-33-2}
+## [0.33.2] - 2024-06-13
+
+[0.33.2]: https://github.com/bazelbuild/rules_python/releases/tag/0.33.2
+
+{#v0-33-2-fixed}
+### Fixed
+* (toolchains) The {obj}`exec_tools_toolchain_type` is disabled by default.
+  To enable it, set {obj}`--//python/config_settings:exec_tools_toolchain=enabled`.
+  This toolchain must be enabled for precompilation to work. This toolchain will
+  be enabled by default in a future release.
+  Fixes [#1967](https://github.com/bazelbuild/rules_python/issues/1967).
+
+{#v0-33-1}
+## [0.33.1] - 2024-06-13
+
+[0.33.1]: https://github.com/bazelbuild/rules_python/releases/tag/0.33.1
+
+{#v0-33-1-fixed}
+### Fixed
+* (py_binary) Fix building of zip file when using `--build_python_zip`
+  argument. Fixes [#1954](https://github.com/bazelbuild/rules_python/issues/1954).
+
+{#v0-33-0}
+## [0.33.0] - 2024-06-12
+
+[0.33.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.33.0
+
+{#v0-33-0-changed}
+### Changed
+* (deps) Upgrade the `pip_install` dependencies to pick up a new version of pip.
+* (toolchains) Optional toolchain dependency: `py_binary`, `py_test`, and
+  `py_library` now depend on the `//python:exec_tools_toolchain_type` for build
+  tools.
+* (deps): Bumped `bazel_skylib` to 1.6.1.
+* (bzlmod): The `python` and internal `rules_python` extensions have been
+  marked as `reproducible` and will not include any lock file entries from now
+  on.
+* (gazelle): Remove gazelle plugin's python deps and make it hermetic.
+  Introduced a new Go-based helper leveraging tree-sitter for syntax analysis.
+  Implemented the use of `pypi/stdlib-list` for standard library module verification.
+* (pip.parse): Do not ignore yanked packages when using `experimental_index_url`.
+  This is to mimic what `uv` is doing. We will print a warning instead.
+* (pip.parse): Add references to all supported wheels when using `experimental_index_url`
+  to allowing to correctly fetch the wheels for the right platform. See the
+  updated docs on how to use the feature. This is work towards addressing
+  [#735](https://github.com/bazelbuild/rules_python/issues/735) and
+  [#260](https://github.com/bazelbuild/rules_python/issues/260). The spoke
+  repository names when using this flag will have a structure of
+  `{pip_hub_prefix}_{wheel_name}_{py_tag}_{abi_tag}_{platform_tag}_{sha256}`,
+  which is an implementation detail which should not be relied on and is there
+  purely for better debugging experience.
+* (bzlmod) The `pythons_hub//:interpreters.bzl` no longer has platform-specific
+  labels which where left there for compatibility reasons. Move to
+  `python_{version}_host` keys if you would like to have access to a Python
+  interpreter that can be used in a repository rule context.
+
+{#v0-33-0-fixed}
+### Fixed
+* (gazelle) Remove `visibility` from `NonEmptyAttr`.
+  Now empty(have no `deps/main/srcs/imports` attr) `py_library/test/binary` rules will
+  be automatically deleted correctly. For example, if `python_generation_mode`
+  is set to package, when `__init__.py` is deleted, the `py_library` generated
+  for this package before will be deleted automatically.
+* (whl_library): Use _is_python_config_setting_ to correctly handle multi-python
+  version dependency select statements when the `experimental_target_platforms`
+  includes the Python ABI. The default python version case within the select is
+  also now handled correctly, stabilizing the implementation.
+* (gazelle) Fix Gazelle failing on Windows with
+  "panic: runtime error: invalid memory address or nil pointer dereference"
+* (bzlmod) remove `pip.parse(annotations)` attribute as it is unused and has been
+  replaced by whl_modifications.
+* (pip) Correctly select wheels when the python tag includes minor versions.
+  See ([#1930](https://github.com/bazelbuild/rules_python/issues/1930))
+* (pip.parse): The lock file is now reproducible on any host platform if the
+  `experimental_index_url` is not used by any of the modules in the dependency
+  chain. To make the lock file identical on each `os` and `arch`, please use
+  the `experimental_index_url` feature which will fetch metadata from PyPI or a
+  different private index and write the contents to the lock file. Fixes
+  [#1643](https://github.com/bazelbuild/rules_python/issues/1643).
+* (pip.parse): Install `yanked` packages and print a warning instead of
+  ignoring them. This better matches the behaviour of `uv pip install`.
+* (toolchains): Now matching of the default hermetic toolchain is more robust
+  and explicit and should fix rare edge-cases where the host toolchain
+  autodetection would match a different toolchain than expected. This may yield
+  to toolchain selection failures when the python toolchain is not registered,
+  but is requested via `//python/config_settings:python_version` flag setting.
+* (doc) Fix the `WORKSPACE` requirement vendoring example. Fixes
+  [#1918](https://github.com/bazelbuild/rules_python/issues/1918).
+
+{#v0-33-0-added}
+### Added
+* (rules) Precompiling Python source at build time is available. but is
+  disabled by default, for now. Set
+  `@rules_python//python/config_settings:precompile=enabled` to enable it
+  by default. A subsequent release will enable it by default. See the
+  [Precompiling docs][precompile-docs] and API reference docs for more
+  information on precompiling. Note this requires Bazel 7+ and the Pystar rule
+  implementation enabled.
+  ([#1761](https://github.com/bazelbuild/rules_python/issues/1761))
+* (rules) Attributes and flags to control precompile behavior: `precompile`,
+  `precompile_optimize_level`, `precompile_source_retention`,
+  `precompile_invalidation_mode`, and `pyc_collection`
+* (toolchains) The target runtime toolchain (`//python:toolchain_type`) has
+  two new optional attributes: `pyc_tag` (tells the pyc filename infix to use) and
+  `implementation_name` (tells the Python implementation name).
+* (toolchains) A toolchain type for build tools has been added:
+  `//python:exec_tools_toolchain_type`.
+* (providers) `PyInfo` has two new attributes: `direct_pyc_files` and
+  `transitive_pyc_files`, which tell the pyc files a target makes available
+  directly and transitively, respectively.
+* `//python:features.bzl` added to allow easy feature-detection in the future.
+* (pip) Allow specifying the requirements by (os, arch) and add extra
+  validations when parsing the inputs. This is a non-breaking change for most
+  users unless they have been passing multiple `requirements_*` files together
+  with `extra_pip_args = ["--platform=manylinux_2_4_x86_64"]`, that was an
+  invalid usage previously but we were not failing the build. From now on this
+  is explicitly disallowed.
+* (toolchains) Added riscv64 platform definition for python toolchains.
+* (gazelle) The `python_visibility` directive now supports the `$python_root$`
+  placeholder, just like the `python_default_visibility` directive does.
+* (rules) A new bootstrap implementation that doesn't require a system Python
+  is available. It can be enabled by setting
+  {obj}`--@rules_python//python/config_settings:bootstrap_impl=script`. It
+  will become the default in a subsequent release.
+  ([#691](https://github.com/bazelbuild/rules_python/issues/691))
+* (providers) `PyRuntimeInfo` has two new attributes:
+  {obj}`PyRuntimeInfo.stage2_bootstrap_template` and
+  {obj}`PyRuntimeInfo.zip_main_template`.
+* (toolchains) A replacement for the Bazel-builtn autodetecting toolchain is
+  available. The `//python:autodetecting_toolchain` alias now uses it.
+* (pip): Support fetching and using the wheels for other platforms. This
+  supports customizing whether the linux wheels are pulled for `musl` or
+  `glibc`, whether `universal2` or arch-specific MacOS wheels are preferred and
+  it also allows to select a particular `libc` version. All of this is done via
+  the `string_flags` in `@rules_python//python/config_settings`. If there are
+  no wheels that are supported for the target platform, `rules_python` will
+  fallback onto building the `sdist` from source. This behaviour can be
+  disabled if desired using one of the available string flags as well.
+* (whl_filegroup) Added a new `whl_filegroup` rule to extract files from a wheel file.
+  This is useful to extract headers for use in a `cc_library`.
+
+[precompile-docs]: /precompiling
+
+{#v0-32-2}
+## [0.32.2] - 2024-05-14
+
+[0.32.2]: https://github.com/bazelbuild/rules_python/releases/tag/0.32.2
+
+{#v0-32-2-fixed}
+### Fixed
+
+* Workaround existence of infinite symlink loops on case insensitive filesystems when targeting linux platforms with recent Python toolchains. Works around an upstream [issue][indygreg-231]. Fixes [#1800][rules_python_1800].
+
+[indygreg-231]: https://github.com/indygreg/python-build-standalone/issues/231
+[rules_python_1800]: https://github.com/bazelbuild/rules_python/issues/1800
+
+{#v0-32-0}
+## [0.32.0] - 2024-05-12
+
+[0.32.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.32.0
+
+{#v0-32-0-changed}
+### Changed
+
+* (bzlmod): The `MODULE.bazel.lock` `whl_library` rule attributes are now
+  sorted in the attributes section. We are also removing values that are not
+  default in order to reduce the size of the lock file.
+* (coverage) Bump `coverage.py` to [7.4.3](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst#version-743--2024-02-23).
+* (deps): Bumped `bazel_features` to 1.9.1 to detect optional support
+  non-blocking downloads.
+* (deps): Updated `pip_tools` to >= 7.4.0
+* (toolchains): Change some old toolchain versions to use [20240224] release to
+  include security fixes `3.8.18`, `3.9.18` and `3.10.13`
+* (toolchains): Bump default toolchain versions to:
+    * `3.8 -> 3.8.19`
+    * `3.9 -> 3.9.19`
+    * `3.10 -> 3.10.14`
+    * `3.11 -> 3.11.9`
+    * `3.12 -> 3.12.3`
 
 ### Fixed
 
 * (whl_library): Fix the experimental_target_platforms overriding for platform
   specific wheels when the wheels are for any python interpreter version. Fixes
   [#1810](https://github.com/bazelbuild/rules_python/issues/1810).
+* (whl_library): Stop generating duplicate dependencies when encountering
+  duplicates in the METADATA. Fixes
+  [#1873](https://github.com/bazelbuild/rules_python/issues/1873).
+* (gazelle) In `project` or `package` generation modes, do not generate `py_test`
+  rules when there are no test files and do not set `main = "__test__.py"` when
+  that file doesn't exist.
+* (whl_library) The group redirection is only added when the package is part of
+  the group potentially fixing aspects that want to traverse a `py_library` graph.
+  Fixes [#1760](https://github.com/bazelbuild/rules_python/issues/1760).
+* (bzlmod) Setting a particular micro version for the interpreter and the
+  `pip.parse` extension is now possible, see the
+  `examples/pip_parse/MODULE.bazel` for how to do it.
+  See [#1371](https://github.com/bazelbuild/rules_python/issues/1371).
+* (refactor) The pre-commit developer workflow should now pass `isort` and `black`
+  checks (see [#1674](https://github.com/bazelbuild/rules_python/issues/1674)).
 
 ### Added
 
-* New Python versions available: `3.11.8`, `3.12.2` using
-  https://github.com/indygreg/python-build-standalone/releases/tag/20240224.
+* (toolchains) Added armv7 platform definition for python toolchains.
+* (toolchains) New Python versions available: `3.11.8`, `3.12.2` using the [20240224] release.
+* (toolchains) New Python versions available: `3.8.19`, `3.9.19`, `3.10.14`, `3.11.9`, `3.12.3` using
+  the [20240415] release.
 * (gazelle) Added a new `python_visibility` directive to control visibility
   of generated targets by appending additional visibility labels.
 * (gazelle) Added a new `python_default_visibility` directive to control the
   _default_ visibility of generated targets. See the [docs][python_default_visibility]
   for details.
+* (gazelle) Added a new `python_test_file_pattern` directive. This directive tells
+  gazelle which python files should be mapped to the `py_test` rule. See the
+  [original issue][test_file_pattern_issue] and the [docs][test_file_pattern_docs]
+  for details.
+* (wheel) Add support for `data_files` attributes in py_wheel rule
+  ([#1777](https://github.com/bazelbuild/rules_python/issues/1777))
+* (py_wheel) `bzlmod` installations now provide a `twine` setup for the default
+  Python toolchain in `rules_python` for version 3.11.
+* (bzlmod) New `experimental_index_url`, `experimental_extra_index_urls` and
+  `experimental_index_url_overrides` to `pip.parse` for using the bazel
+  downloader. If you see any issues, report in
+  [#1357](https://github.com/bazelbuild/rules_python/issues/1357). The URLs for
+  the whl and sdist files will be written to the lock file. Controlling whether
+  the downloading of metadata is done in parallel can be done using
+  `parallel_download` attribute.
+* (gazelle) Add a new annotation `include_dep`. Also add documentation for
+  annotations to `gazelle/README.md`.
+* (deps): `rules_python` depends now on `rules_cc` 0.0.9
+* (pip_parse): A new flag `use_hub_alias_dependencies` has been added that is going
+  to become default in the next release. This makes use of `dep_template` flag
+  in the `whl_library` rule. This also affects the
+  `experimental_requirement_cycles` feature where the dependencies that are in
+  a group would be only accessible via the hub repo aliases. If you still
+  depend on legacy labels instead of the hub repo aliases and you use the
+  `experimental_requirement_cycles`, now is a good time to migrate.
 
-[0.XX.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.XX.0
 [python_default_visibility]: gazelle/README.md#directive-python_default_visibility
+[test_file_pattern_issue]: https://github.com/bazelbuild/rules_python/issues/1816
+[test_file_pattern_docs]: gazelle/README.md#directive-python_test_file_pattern
+[20240224]: https://github.com/indygreg/python-build-standalone/releases/tag/20240224.
+[20240415]: https://github.com/indygreg/python-build-standalone/releases/tag/20240415.
 
-### Changed
-
-* (coverage) Bump `coverage.py` to [7.4.3](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst#version-743--2024-02-23).
 
 ## [0.31.0] - 2024-02-12
 
@@ -263,7 +835,6 @@ A brief description of the categories of changes:
   attribute for every target in the package. This is enabled through a separate
   directive `python_generation_mode_per_file_include_init`.
 
-
 ## [0.27.0] - 2023-11-16
 
 [0.27.0]: https://github.com/bazelbuild/rules_python/releases/tag/0.27.0
@@ -386,8 +957,7 @@ Breaking changes:
 
 ### Added
 
-* (bzlmod, entry_point) Added
-  [`py_console_script_binary`](./docs/py_console_script_binary.md), which
+* (bzlmod, entry_point) Added {obj}`py_console_script_binary`, which
   allows adding custom dependencies to a package's entry points and customizing
   the `py_binary` rule used to build it.
 

--- a/python/private/BUILD.bazel
+++ b/python/private/BUILD.bazel
@@ -98,6 +98,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "glob_excludes_bzl",
+    srcs = ["glob_excludes.bzl"],
+    deps = [":util_bzl"],
+)
+
+bzl_library(
     name = "internal_config_repo_bzl",
     srcs = ["internal_config_repo.bzl"],
     deps = [":bzlmod_enabled_bzl"],

--- a/python/private/glob_excludes.bzl
+++ b/python/private/glob_excludes.bzl
@@ -1,0 +1,32 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"Utilities for glob exclusions."
+
+load(":util.bzl", "IS_BAZEL_7_4_OR_HIGHER")
+
+def _version_dependent_exclusions():
+    """Returns glob exclusions that are sensitive to Bazel version.
+
+    Returns:
+        a list of glob exclusion patterns
+    """
+    if IS_BAZEL_7_4_OR_HIGHER:
+        return []
+    else:
+        return ["**/* *"]
+
+glob_excludes = struct(
+    version_dependent_exclusions = _version_dependent_exclusions,
+)

--- a/python/private/util.bzl
+++ b/python/private/util.bzl
@@ -84,6 +84,21 @@ def add_tag(attrs, tag):
     else:
         attrs["tags"] = [tag]
 
+# Helper to make the provider definitions not crash under Bazel 5.4:
+# Bazel 5.4 doesn't support the `init` arg of `provider()`, so we have to
+# not pass that when using Bazel 5.4. But, not passing the `init` arg
+# changes the return value from a two-tuple to a single value, which then
+# breaks Bazel 6+ code.
+# This isn't actually used under Bazel 5.4, so just stub out the values
+# to get past the loading phase.
+def define_bazel_6_provider(doc, fields, **kwargs):
+    """Define a provider, or a stub for pre-Bazel 7."""
+    if not IS_BAZEL_6_OR_HIGHER:
+        return provider("Stub, not used", fields = []), None
+    return provider(doc = doc, fields = fields, **kwargs)
+
+IS_BAZEL_7_4_OR_HIGHER = hasattr(native, "legacy_globals")
+
 IS_BAZEL_7_OR_HIGHER = hasattr(native, "starlark_doc_extract")
 
 # Bazel 5.4 has a bug where every access of testing.ExecutionInfo is a


### PR DESCRIPTION
Recently we had a setuptool upgrade due to out of date for our internal fork of rules_python.
This https://github.com/bazel-contrib/rules_python/pull/2334 PR has the fix and confirmed from PR:
https://github.com/abnormal-security/source/pull/99798
Cherry picking the fixed commit.